### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/eromano/protractor-retry-angular-cli"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko=true",
     "lint": "eslint .",
     "release": "standard-version",
     "test:mocha": "protractor test/protractor.mocha.conf.js",


### PR DESCRIPTION
Remove postinstall script to avoid any issues in the end applications, the "webdriver" update can be called in the application once all libraries are installed.